### PR TITLE
feat(macros): supports customizing v-model in Vue 2

### DIFF
--- a/packages/macros/src/define-model/transform.ts
+++ b/packages/macros/src/define-model/transform.ts
@@ -314,6 +314,16 @@ export const transformDefineModel = (
         const declaration = node.declaration
         if (declaration.type === 'ObjectExpression') {
           processV2Model(declaration)
+        } else if (
+          declaration.type === 'CallExpression' &&
+          declaration.callee.type === 'Identifier' &&
+          declaration.callee.name === 'defineComponent'
+        ) {
+          declaration.arguments.forEach((item) => {
+            if (item.type === 'ObjectExpression') {
+              processV2Model(item)
+            }
+          })
         }
       }
     }

--- a/packages/macros/src/define-model/transform.ts
+++ b/packages/macros/src/define-model/transform.ts
@@ -4,6 +4,7 @@ import { extractIdentifiers, walkAST } from 'ast-walker-scope'
 import {
   DEFINE_EMITS,
   DEFINE_MODEL,
+  DEFINE_OPTIONS,
   DEFINE_PROPS,
   isCallOf,
   parseSFC,
@@ -148,6 +149,11 @@ export const transformDefineModel = (
     if (kind) modelDeclKind = kind
 
     return true
+  }
+  function processDefineOptionIsModel(node: Node) {
+    if (isCallOf(node, DEFINE_OPTIONS)) {
+      node.arguments.forEach((item) => processV2Model(item))
+    }
   }
 
   function processV2Model(node: Node) {
@@ -331,6 +337,7 @@ export const transformDefineModel = (
   for (const node of scriptSetup.scriptSetupAst as Statement[]) {
     if (node.type === 'ExpressionStatement') {
       processDefinePropsOrEmits(node.expression)
+      processDefineOptionIsModel(node.expression)
       if (processDefineModel(node.expression)) {
         s.remove(node.start! + startOffset, node.end! + startOffset)
       }

--- a/packages/macros/tests/__snapshots__/define-model.test.ts.snap
+++ b/packages/macros/tests/__snapshots__/define-model.test.ts.snap
@@ -106,6 +106,44 @@ const emit = defineEmits<{(evt: 'changeInput', value: string): void
 "
 `;
 
+exports[`define-model > tests/fixtures/define-model/vue2-custom-vmodel-defineComponent.vue 1`] = `
+"<script lang=\\"ts\\">
+import { defineComponent } from 'vue'
+export default defineComponent({
+  model: {
+    prop: 'value',
+    event: 'changeInput'
+  },
+})
+</script>
+<script setup lang=\\"ts\\">import { emitHelper as __emitHelper } from 'unplugin-vue-macros/helper'
+
+
+
+const {value, title,  id } = defineProps<{value: string
+title: string
+ id: string }>()
+
+const emit = defineEmits<{(evt: 'changeInput', value: string): void
+(evt: 'update:title', value: string): void
+
+  (evt: 'change'): void
+}>()
+
+{
+  __emitHelper(emit, 'changeInput', 'hello')
+  __emitHelper(emit, 'update:title', 'world')
+  emit('change')
+
+  {
+    let modelValue = 'world'
+    modelValue = 'foo'
+  }
+}
+</script>
+"
+`;
+
 exports[`define-model > tests/fixtures/define-model/with-define-emits.vue 1`] = `
 "<script setup lang=\\"ts\\">const { modelValue } = defineProps<{
   modelValue: string

--- a/packages/macros/tests/__snapshots__/define-model.test.ts.snap
+++ b/packages/macros/tests/__snapshots__/define-model.test.ts.snap
@@ -69,6 +69,43 @@ const emit = defineEmits<{(evt: 'input', value: string): void
 "
 `;
 
+exports[`define-model > tests/fixtures/define-model/vue2-custom-vmodel.vue 1`] = `
+"<script lang=\\"ts\\">
+export default {
+  model: {
+    prop: 'value',
+    event: 'changeInput'
+  },
+}
+</script>
+<script setup lang=\\"ts\\">import { emitHelper as __emitHelper } from 'unplugin-vue-macros/helper'
+
+
+
+const {value, title,  id } = defineProps<{value: string
+title: string
+ id: string }>()
+
+const emit = defineEmits<{(evt: 'changeInput', value: string): void
+(evt: 'update:title', value: string): void
+
+  (evt: 'change'): void
+}>()
+
+{
+  __emitHelper(emit, 'changeInput', 'hello')
+  __emitHelper(emit, 'update:title', 'world')
+  emit('change')
+
+  {
+    let modelValue = 'world'
+    modelValue = 'foo'
+  }
+}
+</script>
+"
+`;
+
 exports[`define-model > tests/fixtures/define-model/with-define-emits.vue 1`] = `
 "<script setup lang=\\"ts\\">const { modelValue } = defineProps<{
   modelValue: string

--- a/packages/macros/tests/__snapshots__/rollup.test.ts.snap
+++ b/packages/macros/tests/__snapshots__/rollup.test.ts.snap
@@ -30,3 +30,41 @@ const handleClick = () => {
 export { mixed as default };
 "
 `;
+
+exports[`Rollup > fixtures > tests/fixtures/mixed-vue2-model.vue 1`] = `
+"var mixedVue2Model = \`<script lang=\\"ts\\">
+import { defineComponent as DO_defineComponent } from 'vue';
+export default /*#__PURE__*/ DO_defineComponent({
+  name: 'Foo',
+  model: {
+    prop: 'value',
+    event: 'changeInput'
+  },
+});
+</script>
+<script setup lang=\\"ts\\">import { emitHelper as __emitHelper } from 'unplugin-vue-macros/helper'
+
+
+const {modelValue, value,  title } = defineProps<{modelValue: string
+value: string
+
+  title: string
+}>()
+const emit = defineEmits<{(evt: 'update:modelValue', value: string): void
+(evt: 'changeInput', value: string): void
+
+  (evt: 'change'): void
+}>()
+
+
+const handleClick = () => {
+  emit('change')
+  __emitHelper(emit, 'update:modelValue', 'hello, ' + title)
+  __emitHelper(emit, 'changeInput', 'Word,' + title)
+}
+</script>
+\`;
+
+export { mixedVue2Model as default };
+"
+`;

--- a/packages/macros/tests/fixtures/define-model/vue2-custom-vmodel-defineComponent.vue
+++ b/packages/macros/tests/fixtures/define-model/vue2-custom-vmodel-defineComponent.vue
@@ -1,0 +1,32 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+export default defineComponent({
+  model: {
+    prop: 'value',
+    event: 'changeInput'
+  },
+})
+</script>
+<script setup lang="ts">
+let { value, title } = defineModel<{
+  value: string
+  title: string
+}>()
+
+const { id } = defineProps<{ id: string }>()
+
+const emit = defineEmits<{
+  (evt: 'change'): void
+}>()
+
+{
+  value = 'hello'
+  title = 'world'
+  emit('change')
+
+  {
+    let modelValue = 'world'
+    modelValue = 'foo'
+  }
+}
+</script>

--- a/packages/macros/tests/fixtures/define-model/vue2-custom-vmodel.vue
+++ b/packages/macros/tests/fixtures/define-model/vue2-custom-vmodel.vue
@@ -1,0 +1,31 @@
+<script lang="ts">
+export default {
+  model: {
+    prop: 'value',
+    event: 'changeInput'
+  },
+}
+</script>
+<script setup lang="ts">
+let { value, title } = defineModel<{
+  value: string
+  title: string
+}>()
+
+const { id } = defineProps<{ id: string }>()
+
+const emit = defineEmits<{
+  (evt: 'change'): void
+}>()
+
+{
+  value = 'hello'
+  title = 'world'
+  emit('change')
+
+  {
+    let modelValue = 'world'
+    modelValue = 'foo'
+  }
+}
+</script>

--- a/packages/macros/tests/fixtures/mixed-vue2-model.vue
+++ b/packages/macros/tests/fixtures/mixed-vue2-model.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+defineOptions({
+  name: 'Foo',
+  model: {
+    prop: 'value',
+    event: 'changeInput'
+  },
+})
+const { title } = defineProps<{
+  title: string
+}>()
+const emit = defineEmits<{
+  (evt: 'change'): void
+}>()
+let { modelValue, value } = defineModel<{
+  modelValue: string
+  value: string
+}>()
+
+const handleClick = () => {
+  emit('change')
+  modelValue = 'hello, ' + title
+  value = 'Word,' + title
+}
+</script>

--- a/packages/macros/tests/rollup.test.ts
+++ b/packages/macros/tests/rollup.test.ts
@@ -17,9 +17,10 @@ describe('Rollup', () => {
     for (const file of files) {
       it(file.replace(/\\/g, '/'), async () => {
         const filepath = resolve(root, file)
+        const version = filepath.includes('vue2') ? 2 : 3
 
         const unpluginCode = await getCode(filepath, [
-          VueMacros({}),
+          VueMacros({ version }),
           ToString,
         ]).catch((err) => err)
         expect(unpluginCode).toMatchSnapshot()


### PR DESCRIPTION
### Description

add vue2 [Customizing-Component-v-model](https://v2.vuejs.org/v2/guide/components-custom-events.html#Customizing-Component-v-model)

[Example](https://codesandbox.io/s/red-sea-ycblru)

### Additional context
How to test `defineOptions` and `defineModel` together? 😢
<!-- e.g. is there anything you'd like reviewers to focus on? -->

