### PR TITLE
fix(volar): defineSlots without `<script setup>`

### DIFF
--- a/.changeset/strong-mirrors-roll.md
+++ b/.changeset/strong-mirrors-roll.md
@@ -1,0 +1,5 @@
+---
+"@vue-macros/volar": patch
+---
+
+fix defineSlots without <script setup>

--- a/packages/volar/src/define-slots.ts
+++ b/packages/volar/src/define-slots.ts
@@ -62,8 +62,8 @@ function getTypeArg(
     return node.typeArguments[0]
   }
 
-  const sourceFile = sfc.scriptSetupAst!
-  return sourceFile.forEachChild((node) => {
+  const sourceFile = sfc.scriptSetupAst
+  return sourceFile?.forEachChild((node) => {
     if (!ts.isExpressionStatement(node)) return
     return getCallArg(node.expression)
   })


### PR DESCRIPTION
### Description

When using the defineSlots plugin in a project that includes components with no `<script setup>`, the plugin generates an errors because `sfc.scriptSetupAst` is `undefined` (the previous `sfc.scriptSetupAst!` is wrong as this is not guaranteed).

Logged error:
```
/project/node_modules/.pnpm/@vue-macros+volar@0.5.0_vue-tsc@1.0.9+vue@3.2.41/node_modules/@vue-macros/volar/dist/define-slots.js:52
  return sourceFile.forEachChild((node) => {
                    ^

TypeError: Cannot read properties of undefined (reading 'forEachChild')
    at getTypeArg (/project/node_modules/.pnpm/@vue-macros+volar@0.5.0_vue-tsc@1.0.9+vue@3.2.41/node_modules/@vue-macros/volar/dist/define-slots.js:52:21)
    at Object.resolveEmbeddedFile (/project/node_modules/.pnpm/@vue-macros+volar@0.5.0_vue-tsc@1.0.9+vue@3.2.41/node_modules/@vue-macros/volar/dist/define-slots.js:63:23)
    at ReactiveEffect.fn (/project/node_modules/.pnpm/@volar+vue-language-core@1.0.9/node_modules/@volar/vue-language-core/out/sourceFile.js:356:40)
    at ReactiveEffect.run (/project/node_modules/.pnpm/@vue+reactivity@3.2.41/node_modules/@vue/reactivity/dist/reactivity.cjs.js:191:25)
    at get value [as value] (/project/node_modules/.pnpm/@vue+reactivity@3.2.41/node_modules/@vue/reactivity/dist/reactivity.cjs.js:1141:39)
    at /project/node_modules/.pnpm/@volar+vue-language-core@1.0.9/node_modules/@volar/vue-language-core/out/sourceFile.js:368:32
    at Array.map (<anonymous>)
    at ReactiveEffect.fn (/project/node_modules/.pnpm/@volar+vue-language-core@1.0.9/node_modules/@volar/vue-language-core/out/sourceFile.js:367:28)
    at ReactiveEffect.run (/project/node_modules/.pnpm/@vue+reactivity@3.2.41/node_modules/@vue/reactivity/dist/reactivity.cjs.js:191:25)
    at get value [as value] (/project/node_modules/.pnpm/@vue+reactivity@3.2.41/node_modules/@vue/reactivity/dist/reactivity.cjs.js:1141:39)
```

This PR provides a simple fix by using the optional chaining operator in place of the non-null assertion.

Thanks!
