### PR TITLE
fix(short-emits): add dts to pkg files

### DIFF
--- a/.changeset/sour-toes-sit.md
+++ b/.changeset/sour-toes-sit.md
@@ -1,0 +1,5 @@
+---
+"@vue-macros/short-emits": patch
+---
+
+add dts files into publish list

--- a/packages/short-emits/package.json
+++ b/packages/short-emits/package.json
@@ -23,7 +23,9 @@
   },
   "author": "三咲智子 <sxzz@sxzz.moe>",
   "files": [
-    "dist"
+    "dist",
+    "macros.d.ts",
+    "macros-global.d.ts"
   ],
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
### Description

 Macros.d.ts and macros-global.d.ts are missing in short-emits module. This PR is just to fix this.
