### PR TITLE
refactor(common): use getters in SFC

### DIFF
--- a/.changeset/silver-ladybugs-mix.md
+++ b/.changeset/silver-ladybugs-mix.md
@@ -2,4 +2,4 @@
 "@vue-macros/common": patch
 ---
 
-refactor(common): use getters in SFC
+use getters in SFC

--- a/.changeset/silver-ladybugs-mix.md
+++ b/.changeset/silver-ladybugs-mix.md
@@ -1,0 +1,5 @@
+---
+"@vue-macros/common": patch
+---
+
+refactor(common): use getters in SFC

--- a/packages/common/src/vue.ts
+++ b/packages/common/src/vue.ts
@@ -18,8 +18,8 @@ export type SFC = Omit<SFCDescriptor, 'script' | 'scriptSetup'> & {
   script?: _SFCScriptBlock | null
   scriptSetup?: _SFCScriptBlock | null
   lang: string | undefined
-  scriptAst: Program | undefined
-  setupAst: Program | undefined
+  get scriptAst(): Program | undefined
+  get setupAst(): Program | undefined
 } & Pick<SFCParseResult, 'errors'>
 
 export const parseSFC = (code: string, id: string): SFC => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Stricter types

### Linked Issues

none

### Additional context

I also noticed the functions below as declared as `const ... () => ` instead of `function ...() ` while in other parts of the codebase the `function` syntax is used. It might be worth using the same `function` syntax in both places for consistency and discoverability in the project

<!-- e.g. is there anything you'd like reviewers to focus on? -->
