### PR TITLE
docs: correct link path

### DIFF
--- a/docs/zh-CN/macros/index.md
+++ b/docs/zh-CN/macros/index.md
@@ -7,7 +7,7 @@
 - [defineOptions](/zh-CN/macros/define-options)
 - [defineModel](/zh-CN/macros/define-model)
 - [defineProps](/zh-CN/macros/define-props)
-- [definePropsRefs](/macros/define-props-refs) <WarnBadge>尚未稳定</WarnBadge>
+- [definePropsRefs](/zh-CN/macros/define-props-refs) <WarnBadge>尚未稳定</WarnBadge>
 - [defineSlots](/zh-CN/macros/define-slots) <WarnBadge>尚未稳定</WarnBadge>
 - [defineRender](/zh-CN/macros/define-render)
 - [shortEmits](/zh-CN/macros/short-emits)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When reading the Chinese document, I found that in [Pages with errors](https://vue-macros.sxzz.moe/zh-CN/macros) this page click `definePropsRefs` is directly jumped to the English document, can not jump to the Chinese document, seems to be a path error, I will modify its path

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->



<!-- e.g. is there anything you'd like reviewers to focus on? -->
