### PR TITLE
fix: include regex

### DIFF
--- a/.changeset/rotten-eagles-lick.md
+++ b/.changeset/rotten-eagles-lick.md
@@ -1,0 +1,5 @@
+---
+'unplugin-vue-define-options': patch
+---
+
+remove auto import limited with Vue version 2

--- a/.changeset/tender-cheetahs-accept.md
+++ b/.changeset/tender-cheetahs-accept.md
@@ -1,0 +1,16 @@
+---
+"@vue-macros/better-define": patch
+"@vue-macros/common": patch
+"@vue-macros/define-emit": patch
+"@vue-macros/define-models": patch
+"unplugin-vue-define-options": patch
+"@vue-macros/define-prop": patch
+"@vue-macros/define-props-refs": patch
+"@vue-macros/define-props": patch
+"@vue-macros/define-slots": patch
+"@vue-macros/export-props": patch
+"@vue-macros/hoist-static": patch
+"@vue-macros/reactivity-transform": patch
+---
+
+fix include regex

--- a/packages/better-define/src/index.ts
+++ b/packages/better-define/src/index.ts
@@ -8,7 +8,6 @@ import {
 } from '@vue-macros/common'
 import { RollupResolve, setResolveTSFileIdImpl } from '@vue-macros/api'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { type PluginContext } from 'rollup'
 import { transformBetterDefine } from './core'
 
@@ -21,16 +20,11 @@ export type OptionsResolved = MarkRequired<
   'include' | 'version' | 'isProduction'
 >
 
-function resolveOptions(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOptions(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
 
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     isProduction: process.env.NODE_ENV === 'production',
     ...options,
     version,
@@ -41,7 +35,7 @@ const name = 'unplugin-vue-better-define'
 
 export default createUnplugin<Options | undefined, false>(
   (userOptions = {}, { framework }) => {
-    const options = resolveOptions(userOptions, framework)
+    const options = resolveOptions(userOptions)
     const filter = createFilter(options)
 
     const { resolve, handleHotUpdate } = RollupResolve()

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -18,7 +18,7 @@ export const REPO_ISSUE_URL =
 export const REGEX_SRC_FILE = /\.[cm]?[jt]sx?$/
 export const REGEX_SETUP_SFC = /\.setup\.[cm]?[jt]sx?$/
 export const REGEX_VUE_SFC = /\.vue$/
-export const REGEX_VUE_SUB = /\.vue\?vue&/
+export const REGEX_VUE_SUB = /\.vue\?vue&type=script/
 export const REGEX_DTS = /\.d\.[cm]?ts$/
 export const REGEX_NODE_MODULES = /node_modules/
 

--- a/packages/define-emit/src/index.ts
+++ b/packages/define-emit/src/index.ts
@@ -9,7 +9,6 @@ import {
 import { RollupResolve, setResolveTSFileIdImpl } from '@vue-macros/api'
 import { type PluginContext } from 'rollup'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { transformDefineEmit } from './core'
 
 export interface Options extends BaseOptions {
@@ -21,15 +20,10 @@ export type OptionsResolved = MarkRequired<
   'include' | 'version' | 'isProduction'
 >
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     isProduction: process.env.NODE_ENV === 'production',
     ...options,
     version,
@@ -40,7 +34,7 @@ const name = 'unplugin-vue-define-emit'
 
 export default createUnplugin<Options | undefined, false>(
   (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
     const { resolve, handleHotUpdate } = RollupResolve()
 

--- a/packages/define-models/src/index.ts
+++ b/packages/define-models/src/index.ts
@@ -8,7 +8,6 @@ import {
   normalizePath,
 } from '@vue-macros/common'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { transformDefineModels } from './core'
 import {
   emitHelperCode,
@@ -32,15 +31,10 @@ export type OptionsResolved = MarkRequired<
   'include' | 'version' | 'unified'
 >
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     unified: true,
     ...options,
     version,
@@ -50,8 +44,8 @@ function resolveOption(
 const name = 'unplugin-vue-define-models'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {

--- a/packages/define-options/src/index.ts
+++ b/packages/define-options/src/index.ts
@@ -7,21 +7,15 @@ import {
   detectVueVersion,
 } from '@vue-macros/common'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { transformDefineOptions } from './core/transform'
 
 export type Options = BaseOptions
 export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     ...options,
     version,
   }
@@ -30,8 +24,8 @@ function resolveOption(
 const name = 'unplugin-vue-define-options'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {

--- a/packages/define-options/src/index.ts
+++ b/packages/define-options/src/index.ts
@@ -20,7 +20,7 @@ function resolveOption(
   const version = options.version || detectVueVersion()
   return {
     include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
+      framework === 'webpack' ? REGEX_VUE_SUB : []
     ),
     ...options,
     version,

--- a/packages/define-prop/src/index.ts
+++ b/packages/define-prop/src/index.ts
@@ -9,7 +9,6 @@ import {
 import { RollupResolve, setResolveTSFileIdImpl } from '@vue-macros/api'
 import { type PluginContext } from 'rollup'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { type Edition } from './core'
 import { transformDefineProp } from './core'
 
@@ -23,15 +22,10 @@ export type OptionsResolved = MarkRequired<
   'include' | 'version' | 'isProduction' | 'edition'
 >
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     isProduction: process.env.NODE_ENV === 'production',
     edition: 'kevinEdition',
     ...options,
@@ -43,7 +37,7 @@ const name = 'unplugin-vue-define-prop'
 
 export default createUnplugin<Options | undefined, false>(
   (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
     const { resolve, handleHotUpdate } = RollupResolve()
 

--- a/packages/define-props-refs/src/index.ts
+++ b/packages/define-props-refs/src/index.ts
@@ -7,7 +7,6 @@ import {
   detectVueVersion,
 } from '@vue-macros/common'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { transformDefinePropsRefs } from './core/index'
 
 export { transformDefinePropsRefs } from './core'
@@ -15,15 +14,10 @@ export { transformDefinePropsRefs } from './core'
 export type Options = BaseOptions
 export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     ...options,
     version,
   }
@@ -32,8 +26,8 @@ function resolveOption(
 const name = 'unplugin-vue-define-props-refs'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {

--- a/packages/define-props/src/index.ts
+++ b/packages/define-props/src/index.ts
@@ -7,7 +7,6 @@ import {
   detectVueVersion,
 } from '@vue-macros/common'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { transformDefineProps } from './core'
 
 export { transformDefineProps } from './core'
@@ -15,15 +14,10 @@ export { transformDefineProps } from './core'
 export type Options = BaseOptions
 export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     ...options,
     version,
   }
@@ -32,8 +26,8 @@ function resolveOption(
 const name = 'unplugin-vue-define-props'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {

--- a/packages/define-slots/src/index.ts
+++ b/packages/define-slots/src/index.ts
@@ -7,21 +7,15 @@ import {
   detectVueVersion,
 } from '@vue-macros/common'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { transformDefineSlots } from './core'
 
 export type Options = BaseOptions
 export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     ...options,
     version,
   }
@@ -30,8 +24,8 @@ function resolveOption(
 const name = 'unplugin-vue-define-slots'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {

--- a/packages/export-props/src/index.ts
+++ b/packages/export-props/src/index.ts
@@ -7,7 +7,6 @@ import {
   detectVueVersion,
 } from '@vue-macros/common'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { transformExportProps } from './core'
 
 export { transformExportProps as transformDefineProps } from './core'
@@ -15,15 +14,10 @@ export { transformExportProps as transformDefineProps } from './core'
 export type Options = BaseOptions
 export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     ...options,
     version,
   }
@@ -32,8 +26,8 @@ function resolveOption(
 const name = 'unplugin-vue-export-props'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {

--- a/packages/hoist-static/src/index.ts
+++ b/packages/hoist-static/src/index.ts
@@ -1,4 +1,4 @@
-import { type UnpluginContextMeta, createUnplugin } from 'unplugin'
+import { createUnplugin } from 'unplugin'
 import {
   REGEX_SETUP_SFC,
   REGEX_VUE_SFC,
@@ -12,16 +12,11 @@ import { transformHoistStatic } from './core'
 export type Options = BaseOptions
 export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
 
   return {
-    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     ...options,
     version,
   }
@@ -30,8 +25,8 @@ function resolveOption(
 const name = 'unplugin-vue-hoist-static'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {

--- a/packages/reactivity-transform/src/index.ts
+++ b/packages/reactivity-transform/src/index.ts
@@ -9,7 +9,6 @@ import {
   detectVueVersion,
   normalizePath,
 } from '@vue-macros/common'
-import { type UnpluginContextMeta } from 'unplugin'
 import { type BaseOptions, type MarkRequired } from '@vue-macros/common'
 import { shouldTransform, transform } from './core/impl'
 import { transformVueSFC } from './core'
@@ -18,15 +17,10 @@ import { helperCode, helperId } from './core/helper'
 export type Options = BaseOptions
 export type OptionsResolved = MarkRequired<Options, 'include' | 'version'>
 
-function resolveOption(
-  options: Options,
-  framework: UnpluginContextMeta['framework']
-): OptionsResolved {
+function resolveOption(options: Options): OptionsResolved {
   const version = options.version || detectVueVersion()
   return {
-    include: [REGEX_SRC_FILE, REGEX_VUE_SFC, REGEX_SETUP_SFC].concat(
-      version === 2 && framework === 'webpack' ? REGEX_VUE_SUB : []
-    ),
+    include: [REGEX_SRC_FILE, REGEX_VUE_SFC, REGEX_SETUP_SFC, REGEX_VUE_SUB],
     exclude: [REGEX_NODE_MODULES],
     ...options,
     version,
@@ -36,8 +30,8 @@ function resolveOption(
 const name = 'unplugin-reactivity-transform'
 
 export default createUnplugin<Options | undefined, false>(
-  (userOptions = {}, { framework }) => {
-    const options = resolveOption(userOptions, framework)
+  (userOptions = {}) => {
+    const options = resolveOption(userOptions)
     const filter = createFilter(options)
 
     return {
@@ -65,7 +59,7 @@ export default createUnplugin<Options | undefined, false>(
         if (
           REGEX_VUE_SFC.test(id) ||
           REGEX_SETUP_SFC.test(id) ||
-          (framework === 'webpack' && REGEX_VUE_SUB.test(id))
+          REGEX_VUE_SUB.test(id)
         ) {
           return transformVueSFC(code, id)
         } else if (shouldTransform(code)) {


### PR DESCRIPTION
### Description

Improve auto import for project with `@vue/cli-service@5` with Vue3.

I used `unplugin-vue-define-options@1.3.3` in my project, and I need to specific the include option in my `vue.config.js` file.
```ts
UnpluginDefineOptions({ version: 3, include: [/\.setup\.[cm]?[jt]sx?$/, /\.vue$/, /\.vue\?vue&/] })
```
Just remove original Vue version 2 limited to include origin reg `REGEX_VUE_SUB` as default can solve this problem.

### Linked Issues

close #327 

### Additional context

Reproduction link https://stackblitz.com/edit/vitejs-vite-drvu4g?file=src/App.vue
